### PR TITLE
:tada: format userCount one time instead of 2 times

### DIFF
--- a/src/interactions/botinfo.ts
+++ b/src/interactions/botinfo.ts
@@ -22,7 +22,7 @@ const choices: Choices[] = [
         bot.guilds.cache.reduce((a, g) => a + g.memberCount, 0),
       );
 
-      return `${bot.utils.formatNumber(userCount)} ${lang.BOT.USERS}`;
+      return `${userCount} ${lang.BOT.USERS}`;
     },
   },
   {


### PR DESCRIPTION
why you format 2 times?