### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/interactions/music/Lyrics.ts
+++ b/src/interactions/music/Lyrics.ts
@@ -68,7 +68,7 @@ export default class LyricsCommand extends SubCommand {
     }
 
     if (embed.description!.length >= 2048) {
-      embed.setDescription(`${songLyrics.substr(0, 2045)}...`);
+      embed.setDescription(`${songLyrics.slice(0, 2045)}...`);
     }
 
     await interaction.editReply({ embeds: [embed] });

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -203,7 +203,7 @@ export class Util {
       }
 
       if (jsonString?.length >= 2048) {
-        jsonString = jsonString ? `${jsonString?.substr(0, 2045)}...` : "";
+        jsonString = jsonString ? `${jsonString?.slice(0, 2045)}...` : "";
       }
 
       if (typeof stack === "string" && stack.length >= 2048) {
@@ -216,7 +216,7 @@ export class Util {
         .addField("Code", code.toString(), true)
         .addField("httpStatus", httpStatus.toString(), true)
         .addField("Timestamp", this.bot.logger.now, true)
-        .addField("Request data", codeBlock(jsonString?.substr(0, 2045)))
+        .addField("Request data", codeBlock(jsonString?.slice(0, 2045)))
         .setDescription(codeBlock(stack as string))
         .setColor(type === "error" ? "RED" : "ORANGE");
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.