### PR TITLE
[bugfix] fixed the command list containing the numbers

### DIFF
--- a/src/scripts/generateCommandList.ts
+++ b/src/scripts/generateCommandList.ts
@@ -4,6 +4,7 @@ import { Collection } from "discord.js";
 import { Bot } from "structures/Bot";
 import { Command } from "structures/Command/Command";
 import { SubCommand } from "structures/Command/SubCommand";
+import { typeToString } from "utils/HandlersUtil";
 
 type TCommand = Command | SubCommand;
 type Commands = Collection<string, TCommand>;
@@ -38,7 +39,7 @@ function subCommandItem(cmd: TCommand) {
           .map((v) => {
             const requiredText = "required" in v && v.required ? "Required" : "Optional";
 
-            return `${v.name} (${v.type} / ${requiredText})`;
+            return `${v.name} (${typeToString(v.type)} / ${requiredText})`;
           })
           .join(", ")
       : "N/A"

--- a/src/utils/HandlersUtil.ts
+++ b/src/utils/HandlersUtil.ts
@@ -5,6 +5,7 @@ import { Event } from "structures/Event";
 import { Feature } from "structures/Feature";
 import { Helper } from "structures/Helper";
 import { Command } from "structures/Command/Command";
+import { ApplicationCommandOptionType } from "discord.js";
 
 type Structures = Event | Feature | Helper | SubCommand | Command;
 
@@ -47,5 +48,34 @@ function getType(item: Structures) {
   }
   if (item instanceof SubCommand) {
     return "SUB_COMMAND";
+  }
+}
+
+export function typeToString(type: ApplicationCommandOptionType): string {
+  switch (type) {
+    case ApplicationCommandOptionType.Subcommand:
+      return "Subcommand";
+    case ApplicationCommandOptionType.SubcommandGroup:
+      return "SubcommandGroup";
+    case ApplicationCommandOptionType.String:
+      return "String";
+    case ApplicationCommandOptionType.Integer:
+      return "Integer";
+    case ApplicationCommandOptionType.Boolean:
+      return "Boolean";
+    case ApplicationCommandOptionType.User:
+      return "User";
+    case ApplicationCommandOptionType.Channel:
+      return "Channel";
+    case ApplicationCommandOptionType.Role:
+      return "Role";
+    case ApplicationCommandOptionType.Mentionable:
+      return "Mentionable";
+    case ApplicationCommandOptionType.Number:
+      return "Number";
+    case ApplicationCommandOptionType.Attachment:
+      return "Attachment";
+    default:
+      throw new Error("Unreachable");
   }
 }


### PR DESCRIPTION
[bugfix] fixed the command list containing the numbers but not the name of the command options type

example of fixed types (I didn't generate the command list): [diff example for docs/COMMANDS.md](https://github.com/Totto16/ghostybot/compare/a1b0dcefc35ed7604ebde5e4f351323b1044d24c...1de83f9149f83f62aa3cbb9e33b48cc89f785ab9#diff-4c28082d6aff974cdefce4d186f10aa9515a94001993828f660514f387f009e8)

It basically changes all numbers to their according string definition:

3 => String 
4 => Integer
... etc.


